### PR TITLE
Add Table of Contents component

### DIFF
--- a/example/src/App.svelte
+++ b/example/src/App.svelte
@@ -12,6 +12,7 @@
     import { setEditorContext } from "@/states/toolbar"
     import { createEditor } from "@/utils/editor"
     import { aligns, headingLevels } from "@/utils/editor-presets"
+    import TableOfContents from "@/components/TableOfContents.svelte"
 
     import { onMount } from "svelte"
     /*
@@ -88,5 +89,6 @@
     <div class="size-full overflow-y-auto px-4">
         <div class="px-10 py-6 max-w-[826px] min-h-full mx-auto bg-white dark:bg-neutral-700 shadow-xl"
              bind:this={divRef}></div>
+        <TableOfContents />
     </div>
 </div>

--- a/example/src/App.svelte
+++ b/example/src/App.svelte
@@ -12,7 +12,7 @@
     import { setEditorContext } from "@/states/toolbar"
     import { createEditor } from "@/utils/editor"
     import { aligns, headingLevels } from "@/utils/editor-presets"
-    import TableOfContents from "@/components/TableOfContents.svelte"
+    import TOC from "@/components/TOC.svelte"
 
     import { onMount } from "svelte"
     /*
@@ -89,6 +89,6 @@
     <div class="size-full overflow-y-auto px-4">
         <div class="px-10 py-6 max-w-[826px] min-h-full mx-auto bg-white dark:bg-neutral-700 shadow-xl"
              bind:this={divRef}></div>
-        <TableOfContents />
+        <TOC />
     </div>
 </div>

--- a/example/src/components/TOC.svelte
+++ b/example/src/components/TOC.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+    import { onMount } from "svelte";
+    import { getEditorContext } from "@/states/toolbar";
+    import EditorTransactionEvent from "@/components/EditorTransactionEvent.svelte";
+
+    const ctx = getEditorContext();
+
+    let headings: { level: number; text: string }[] = [];
+
+    const updateHeadings = () => {
+        const doc = ctx.editor.state.doc;
+        const newHeadings: { level: number; text: string }[] = [];
+
+        doc.descendants((node) => {
+            if (node.type.name === "heading") {
+                newHeadings.push({
+                    level: node.attrs.level,
+                    text: node.textContent,
+                });
+            }
+        });
+
+        headings = newHeadings;
+    };
+
+    onMount(() => {
+        updateHeadings();
+    });
+</script>
+
+<EditorTransactionEvent {updateHeadings} />
+
+<div class="toc">
+    <h2>Table of Contents</h2>
+    <ul>
+        {#each headings as heading}
+            <li class="heading-{heading.level}">
+                <a href="#">{heading.text}</a>
+            </li>
+        {/each}
+    </ul>
+</div>
+
+<style>
+    .toc {
+        position: fixed;
+        top: 120px;
+        right: 20px;
+        width: 200px;
+        background: white;
+        border: 1px solid #ccc;
+        padding: 10px;
+        box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    }
+
+    .toc h2 {
+        margin-top: 0;
+    }
+
+    .toc ul {
+        list-style: none;
+        padding-left: 0;
+    }
+
+    .toc li {
+        margin-bottom: 5px;
+    }
+
+    .toc .heading-1 {
+        font-weight: bold;
+    }
+
+    .toc .heading-2 {
+        padding-left: 10px;
+    }
+
+    .toc .heading-3 {
+        padding-left: 20px;
+    }
+
+    .toc .heading-4 {
+        padding-left: 30px;
+    }
+
+    .toc .heading-5 {
+        padding-left: 40px;
+    }
+
+    .toc .heading-6 {
+        padding-left: 50px;
+    }
+</style>

--- a/example/src/components/TableOfContents.svelte
+++ b/example/src/components/TableOfContents.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+    import { onMount } from "svelte";
+    import { getEditorContext } from "@/states/toolbar";
+    import EditorTransactionEvent from "@/components/EditorTransactionEvent.svelte";
+
+    const ctx = getEditorContext();
+
+    let headings: { level: number; text: string }[] = [];
+
+    const updateHeadings = () => {
+        const doc = ctx.editor.state.doc;
+        const newHeadings: { level: number; text: string }[] = [];
+
+        doc.descendants((node) => {
+            if (node.type.name === "heading") {
+                newHeadings.push({
+                    level: node.attrs.level,
+                    text: node.textContent,
+                });
+            }
+        });
+
+        headings = newHeadings;
+    };
+
+    onMount(() => {
+        updateHeadings();
+    });
+</script>
+
+<EditorTransactionEvent {updateHeadings} />
+
+<div class="toc">
+    <h2>Table of Contents</h2>
+    <ul>
+        {#each headings as heading}
+            <li class="heading-{heading.level}">
+                <a href="#">{heading.text}</a>
+            </li>
+        {/each}
+    </ul>
+</div>
+
+<style>
+    .toc {
+        position: fixed;
+        top: 120px;
+        right: 20px;
+        width: 200px;
+        background: white;
+        border: 1px solid #ccc;
+        padding: 10px;
+        box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    }
+
+    .toc h2 {
+        margin-top: 0;
+    }
+
+    .toc ul {
+        list-style: none;
+        padding-left: 0;
+    }
+
+    .toc li {
+        margin-bottom: 5px;
+    }
+
+    .toc .heading-1 {
+        font-weight: bold;
+    }
+
+    .toc .heading-2 {
+        padding-left: 10px;
+    }
+
+    .toc .heading-3 {
+        padding-left: 20px;
+    }
+
+    .toc .heading-4 {
+        padding-left: 30px;
+    }
+
+    .toc .heading-5 {
+        padding-left: 40px;
+    }
+
+    .toc .heading-6 {
+        padding-left: 50px;
+    }
+</style>

--- a/example/src/states/toolbar.ts
+++ b/example/src/states/toolbar.ts
@@ -21,6 +21,7 @@ export interface ToolbarState {
     isTextAlign: AlignStyle | ""
     isBlockquote: boolean
     isCodeBlock: boolean
+    tocHeadings: { level: number; text: string }[] // Pb2db
 }
 
 export const setEditorContext = (state: ToolbarState) => {
@@ -30,3 +31,20 @@ export const setEditorContext = (state: ToolbarState) => {
 export const getEditorContext = () => {
     return getContext(toolbarStateKey) as ToolbarState
 }
+
+export const updateTOCHeadings = (editor: Editor) => {
+    const doc = editor.state.doc;
+    const newHeadings: { level: number; text: string }[] = [];
+
+    doc.descendants((node) => {
+        if (node.type.name === "heading") {
+            newHeadings.push({
+                level: node.attrs.level,
+                text: node.textContent,
+            });
+        }
+    });
+
+    const state = getEditorContext();
+    state.tocHeadings = newHeadings;
+};

--- a/example/src/utils/editor.ts
+++ b/example/src/utils/editor.ts
@@ -163,3 +163,21 @@ export const createEditor = (options?: Partial<EditorOptions>) => {
         })
     }
 }
+
+export const getHeadingsFromEditor = (editor: Editor) => {
+    const headings: { text: string, level: number, id: string }[] = []
+    const content = editor.getJSON()
+
+    const traverse = (node: any) => {
+        if (node.type === "heading") {
+            const id = node.attrs.id || `heading-${headings.length + 1}`
+            headings.push({ text: node.content[0].text, level: node.attrs.level, id })
+        }
+        if (node.content) {
+            node.content.forEach(traverse)
+        }
+    }
+
+    content.content.forEach(traverse)
+    return headings
+}


### PR DESCRIPTION
Implement a fixed Table of Contents (TOC) for the current editing document.

* **App.svelte**
  - Import the new `TableOfContents` component.
  - Add the `TableOfContents` component to the DOM.

* **TableOfContents.svelte**
  - Create a new Svelte component for the Table of Contents.
  - Use the `getEditorContext` function to access the editor state.
  - Render a list of headings from the current document.
  - Add styles for the Table of Contents to be fixed on the side of the editor.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/aolyang/tiptap-contentful/pull/4?shareId=c8401879-286b-406b-83a6-1bf4b9f47c90).